### PR TITLE
Use owasm-std 0.10 and bump to 0.7.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,8 @@ categories = ["no-std", "embedded"]
 parity-hash = { version = "1.2.2", default-features = false }
 
 [dependencies]
-owasm-std = "0.12"
+#owasm-std = "0.12"
+owasm-std = { git = "https://github.com/oasislabs/owasm-std", branch = "0.10.0" }
 
 [dependencies.uint]
 version = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "owasm-ethereum"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["NikVolf <nikvolf@gmail.com>", "Oasis Labs <info@oasislabs.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,7 @@ categories = ["no-std", "embedded"]
 parity-hash = { version = "1.2.2", default-features = false }
 
 [dependencies]
-#owasm-std = "0.12"
-owasm-std = { git = "https://github.com/oasislabs/owasm-std", branch = "0.10.0" }
+owasm-std = "0.10"
 
 [dependencies.uint]
 version = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["no-std", "embedded"]
 parity-hash = { version = "1.2.2", default-features = false }
 
 [dependencies]
-pwasm-std = "0.10"
+owasm-std = "0.12"
 
 [dependencies.uint]
 version = "0.4"
@@ -33,4 +33,4 @@ default-features = false
 default = []
 kip4 = []
 kip6 = []
-std = ["pwasm-std/std", "parity-hash/std", "uint/std", "byteorder/std"]
+std = ["owasm-std/std", "parity-hash/std", "uint/std", "byteorder/std"]

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -2,7 +2,7 @@
 
 use hash::{H256, Address};
 use uint::U256;
-use pwasm_std;
+use owasm_std;
 
 /// Generic wasm error
 #[derive(Debug)]
@@ -302,13 +302,13 @@ pub fn log(topics: &[H256], data: &[u8]) {
 /// Allocates and requests [`call`] arguments (input)
 ///
 /// Input data comes either with external transaction or from [`call`] input value.
-pub fn input() -> pwasm_std::Vec<u8> {
+pub fn input() -> owasm_std::Vec<u8> {
 	let len = unsafe { external::input_length() };
 
 	match len {
-		0 => pwasm_std::Vec::new(),
+		0 => owasm_std::Vec::new(),
 		non_zero => {
-			let mut data = pwasm_std::Vec::with_capacity(non_zero as usize);
+			let mut data = owasm_std::Vec::with_capacity(non_zero as usize);
 			unsafe {
 				data.set_len(non_zero as usize);
 				external::fetch_input(data.as_mut_ptr());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![cfg_attr(not(feature="std"), no_std)]
 
-extern crate pwasm_std;
+extern crate owasm_std;
 extern crate parity_hash as hash;
 extern crate uint;
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,4 +1,4 @@
-//! Storage extensions for pwasm-ethereum.
+//! Storage extensions for owasm-ethereum.
 //! Storage api is a key-value storage where both key and value are 32 bytes in len
 
 use hash::H256;


### PR DESCRIPTION
I tried using v0.12 but there was an issue here: rust-random/rand#503 that made the builds break for `wasm32-unknown-unknown`.